### PR TITLE
remove need to clone kernel and generate kernel patch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'optimize'
 
 env:
   REGISTRY: ghcr.io

--- a/add-gasket.sh
+++ b/add-gasket.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -ex
+
+KERNEL_DIR="${1:-$PWD}"
+GASKET_VERSION=97aeba584efd18983850c36dcf7384b0185284b3
+
+TMP_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'gasket')
+
+git clone https://github.com/google/gasket-driver "${TMP_DIR}/gasket"
+cd "${TMP_DIR}/gasket"
+git checkout "${GASKET_VERSION}"
+
+# add gasket to source files to kernel (in same location they were added in 4.19...and later removed)
+cp -fr "${TMP_DIR}/gasket/src" "${KERNEL_DIR}/drivers/staging/gasket"
+
+# include gasket in the drivers menu
+sed -i.bak '/endmenu/i \
+\
+source "drivers/staging/gasket/Kconfig"\
+\
+' "${KERNEL_DIR}/drivers/Kconfig"
+rm -f "${KERNEL_DIR}/drivers/Kconfig.bak"
+
+# add gasket to the drivers Makefile
+echo 'obj-$(CONFIG_STAGING_GASKET_FRAMEWORK)	+= staging/gasket/' >> "${KERNEL_DIR}/drivers/Makefile"

--- a/add-gasket.sh
+++ b/add-gasket.sh
@@ -14,6 +14,9 @@ git checkout "${GASKET_VERSION}"
 # add gasket to source files to kernel (in same location they were added in 4.19...and later removed)
 cp -fr "${TMP_DIR}/gasket/src" "${KERNEL_DIR}/drivers/staging/gasket"
 
+sed -i.bak 's/obj-m/obj-y/' "${KERNEL_DIR}/drivers/staging/gasket/Makefile"
+rm -f "${KERNEL_DIR}/drivers/staging/gasket/Makefile.bak"
+
 # include gasket in the drivers menu
 sed -i.bak '/endmenu/i \
 \

--- a/create-pkgs-patch.sh
+++ b/create-pkgs-patch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# re-creates the ./prepare.gasket.patch from the modified work/pkgs/kernel/prepare/
+# this should be run manually and the updated prepare.gasket.patch should be committed
+(cd work/pkgs && git diff --no-prefix kernel/prepare > ../../prepare.gasket.patch)

--- a/prepare.gasket.patch
+++ b/prepare.gasket.patch
@@ -1,17 +1,13 @@
 diff --git kernel/prepare/pkg.yaml kernel/prepare/pkg.yaml
-index 37b01e3..5615ff9 100644
+index 37b01e3..441ce61 100644
 --- kernel/prepare/pkg.yaml
 +++ kernel/prepare/pkg.yaml
-@@ -40,6 +40,12 @@ steps:
+@@ -40,6 +40,8 @@ steps:
          done
  
          make mrproper
 +      - |
-+        set -e
-+        patch -p0 < /pkg/patches/gasket.patch
-+        grep 'gasket' drivers/Kconfig
-+        grep 'gasket' drivers/Makefile
-+        ls -la drivers/staging/gasket
++        /pkg/scripts/add-gasket.sh
        - |
          cd /toolchain && git clone https://github.com/a13xp0p0v/kconfig-hardened-check.git
        - |


### PR DESCRIPTION
Instead, we will tell pkgs to run a script to make the changes to the kernel, rather than cloning the kernel, making the changes, creating a patch from those changes and applying a patch during the pkgs build. This saves the build from having to pull an extra ~1.5GB of data on each build.

This also fixes so that the gasket module is builtin instead of an module that needs to be enabled.